### PR TITLE
HOTFIX: Fix frontend type mismatch causing blank page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { PriceChart } from './components/PriceChart';
 import { MobileCountrySelector } from './components/MobileCountrySelector';
 import IndexSelector from './components/IndexSelector';
 import { useApi } from './hooks/useApi';
-import type { Country, HistoryResponse } from './types/api';
+import type { HistoryResponse, CountriesResponse } from './types/api';
 
 const API_BASE = '/api/v1';
 
@@ -25,7 +25,8 @@ const getModeLabels = (base: BaseCurrency): Record<ChartMode, string> => ({
 
 function App() {
   const [selectedIndex, setSelectedIndex] = useState<string>('bigmac');
-  const { data: countries, loading: countriesLoading } = useApi<Country[]>(`/countries?type=${selectedIndex}`);
+  const { data: countriesData, loading: countriesLoading } = useApi<CountriesResponse>(`/countries?type=${selectedIndex}`);
+  const countries = countriesData?.countries || [];
   const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
   const [historyData, setHistoryData] = useState<HistoryResponse | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);


### PR DESCRIPTION
## Problem
Production site shows blank page after PR #2 deployment. React loads and makes API calls successfully but fails to render silently.

## Root Cause
The `/api/v1/countries?type=` endpoint returns `{index_type, countries, count}` (CountriesResponse) but App.tsx line 23 expects `Country[]`, causing a type mismatch that prevents React from rendering.

## Solution
- Updated App.tsx to use `CountriesResponse` type
- Destructure `countries` array from the response object
- Remove unused `Country` import

## Testing
✅ Tested locally with Docker containers
✅ Frontend renders correctly with IndexSelector
✅ Country list populates properly
✅ All API endpoints return correct data

## Impact
CRITICAL - This fixes the production outage. Site is completely down without this fix.

## Related
- Follows PR #3 (backward compatibility hotfix)
- Fixes issue introduced in PR #2 by subagent timeout